### PR TITLE
Fixing bug for PHP 7.2 compatibility

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,4 +1,4 @@
 build:
     environment:
         php:
-            version: 7.1
+            version: 7.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 7.0
   - 7.1
+  - 7.2
 
 sudo: false
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,7 +6,7 @@
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
-         processIsolation="false"
+         processIsolation="true"
          stopOnError="false"
          stopOnFailure="false"
          syntaxCheck="true"

--- a/src/Support/Yaml.php
+++ b/src/Support/Yaml.php
@@ -53,7 +53,7 @@ class Yaml
         preg_match_all('/{{(.*)}}/', $contents, $matches);
 
         foreach ($matches[0] as $key => $match) {
-            if (count($match)) {
+            if (! empty($match)) {
                 $contents = str_replace($matches[0][$key], $this->resolveVariable($matches[1][$key]), $contents);
             }
         }


### PR DESCRIPTION
I am running PHP 7.2.0. When I try to run `php artisan` on 7.2 with this package installed, I get the following error:

```
In Yaml.php line 56:
                                                                              
  count(): Parameter must be an array or an object that implements Countable
```

Here's the full stacktrace:

```
[2017-12-15 16:52:37] local.ERROR: count(): Parameter must be an array or an object that implements Countable {"exception":"[object] (ErrorException(code: 0): count(): Parameter must be an array or an object that implements Countable at myapp/vendor/pragmarx/health/src/Support/Yaml.php:56)
[stacktrace]
#0 [internal function]: Illuminate\\Foundation\\Bootstrap\\HandleExceptions->handleError(2, 'count(): Parame...', 'myapp...', 56, Array)
#1 myapp/vendor/pragmarx/health/src/Support/Yaml.php(56): count('{{ app.url }}')
#2 myapp/vendor/pragmarx/health/src/Support/Yaml.php(37): PragmaRX\\Health\\Support\\Yaml->replaceContents('name: Http\
abbr...')
#3 myapp/vendor/pragmarx/health/src/Support/Yaml.php(111): PragmaRX\\Health\\Support\\Yaml->parseFile('name: Http\
abbr...')
#4 myapp/vendor/pragmarx/health/src/Support/Yaml.php(25): PragmaRX\\Health\\Support\\Yaml->loadFile('myapp...', 'name: Http\
abbr...', true)
#5 myapp/vendor/laravel/framework/src/Illuminate/Support/Collection.php(910): PragmaRX\\Health\\Support\\Yaml->PragmaRX\\Health\\Support\\{closure}('Http.yml', 7)
#6 myapp/vendor/pragmarx/health/src/Support/Yaml.php(26): Illuminate\\Support\\Collection->mapWithKeys(Object(Closure))
#7 myapp/vendor/pragmarx/health/src/Support/ResourceLoader.php(185): PragmaRX\\Health\\Support\\Yaml->loadYamlFromDir('myapp...')
#8 myapp/vendor/pragmarx/health/src/Support/ResourceLoader.php(163): PragmaRX\\Health\\Support\\ResourceLoader->loadResourcesFiles()
#9 myapp/vendor/pragmarx/health/src/Support/ResourceLoader.php(206): PragmaRX\\Health\\Support\\ResourceLoader->loadFiles()
#10 myapp/vendor/pragmarx/health/src/Support/ResourceLoader.php(221): PragmaRX\\Health\\Support\\ResourceLoader->loadResourcesForType('files', Object(Illuminate\\Support\\Collection))
#11 myapp/vendor/pragmarx/health/src/Support/ResourceLoader.php(126): PragmaRX\\Health\\Support\\ResourceLoader->loadResourcesFrom('files', 'both', Object(Illuminate\\Support\\Collection))
#12 myapp/vendor/pragmarx/health/src/Support/ResourceLoader.php(75): PragmaRX\\Health\\Support\\ResourceLoader->load()
#13 myapp/vendor/pragmarx/health/src/ServiceProvider.php(251): PragmaRX\\Health\\Support\\ResourceLoader->getResources()
#14 myapp/vendor/pragmarx/health/src/ServiceProvider.php(321): PragmaRX\\Health\\ServiceProvider->registerResourcesRoutes()
#15 myapp/vendor/pragmarx/health/src/ServiceProvider.php(240): PragmaRX\\Health\\ServiceProvider->registerRoutes()
#16 myapp/vendor/laravel/framework/src/Illuminate/Foundation/Application.php(586): PragmaRX\\Health\\ServiceProvider->register()
#17 myapp/vendor/laravel/framework/src/Illuminate/Foundation/ProviderRepository.php(75): Illuminate\\Foundation\\Application->register(Object(PragmaRX\\Health\\ServiceProvider))
#18 myapp/vendor/laravel/framework/src/Illuminate/Foundation/Application.php(561): Illuminate\\Foundation\\ProviderRepository->load(Array)
#19 myapp/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/RegisterProviders.php(17): Illuminate\\Foundation\\Application->registerConfiguredProviders()
#20 myapp/vendor/laravel/framework/src/Illuminate/Foundation/Application.php(213): Illuminate\\Foundation\\Bootstrap\\RegisterProviders->bootstrap(Object(Illuminate\\Foundation\\Application))
#21 myapp/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php(296): Illuminate\\Foundation\\Application->bootstrapWith(Array)
#22 myapp/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php(119): Illuminate\\Foundation\\Console\\Kernel->bootstrap()
#23 myapp/artisan(37): Illuminate\\Foundation\\Console\\Kernel->handle(Object(Symfony\\Component\\Console\\Input\\ArgvInput), Object(Symfony\\Component\\Console\\Output\\ConsoleOutput))
#24 {main}
"} 
```

With PHP 7.2, the `count()` method now requires either an array or a Countable object. A string was passed in, `{{ app.url }}`. Previous to 7.2, this method would return `1`, satisfying the condition on line 56. To replicate the behavior with 7.2, the closest function I found was `empty()`, where doing `!empty()` would return the same true value with a nonempty string. `empty()` also works on arrays, if an array is passed in.

I've updated CI to start testing on PHP 7.2 as well.