### PR TITLE
It's not compatible with 4.x anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Use Composer to install it:
 
 ## Installing on Laravel
 
-Add the Service Provider to your `app/config/app.php` (Laravel 4.x) or `config/app.php` (Laravel 5.x):
+Add the Service Provider to your `config/app.php`:
 
     PragmaRX\Health\ServiceProvider::class,
 


### PR DESCRIPTION
It's not compatible with 4.x anymore. According to the `composer.json` and the text in "requirement section": 

>  ## Requirements
> - PHP 5.6+
> - Laravel 5.3+