### PR TITLE
Ability to change model

### DIFF
--- a/src/Support/Traits/Database.php
+++ b/src/Support/Traits/Database.php
@@ -49,7 +49,7 @@ trait Database
 
     protected function saveResultsToDatabase($target, $result)
     {
-        $model = config('health.database.model');
+        $model = config('health.database.model', HealthCheck::class);
 
         $model::create([
             'resource_name' => $resource = $target->resource->name,

--- a/src/Support/Traits/Database.php
+++ b/src/Support/Traits/Database.php
@@ -49,7 +49,9 @@ trait Database
 
     protected function saveResultsToDatabase($target, $result)
     {
-        HealthCheck::create([
+        $model = config('health.database.model');
+
+        $model::create([
             'resource_name' => $resource = $target->resource->name,
             'resource_slug' => $target->resource->slug,
             'target_name' => $target->name,
@@ -62,7 +64,7 @@ trait Database
             'value_human' => $result->valueHuman,
         ]);
 
-        return HealthCheck::where([
+        return $model::where([
             'resource_slug' => $target->resource->slug,
             'target_name' => $target->name,
         ])

--- a/src/config/health.php
+++ b/src/config/health.php
@@ -27,6 +27,8 @@ return [
         ],
 
         'max_records' => 30,
+
+        'model' => PragmaRX\Health\Data\Models\HealthCheck::class,
     ],
 
     'services' => [


### PR DESCRIPTION
On some projects i use Mongodb storage with `jenssegers/mongodb` package, and all my models must extend `Jenssegers\Mongodb\Eloquent\Model` class instead of `Illuminate\Database\Eloquent\Model`. Ability to change model class seems to be best solution in this case.