### PR TITLE
Refactored unneeded ternary operator

### DIFF
--- a/src/config/health.php
+++ b/src/config/health.php
@@ -12,7 +12,7 @@ return [
     'sort_by' => 'slug',
 
     'cache' => [
-        'minutes' => config('app.debug') ? false : true, // false = disabled
+        'minutes' => !config('app.debug'), // false = disabled
 
         'key' => 'health-resources',
     ],

--- a/src/config/health.php
+++ b/src/config/health.php
@@ -12,7 +12,7 @@ return [
     'sort_by' => 'slug',
 
     'cache' => [
-        'minutes' => !config('app.debug'), // false = disabled
+        'minutes' => ! config('app.debug'), // false = disabled
 
         'key' => 'health-resources',
     ],


### PR DESCRIPTION
As `config()` helper will return truthy/falsey value, there is no need for ternary operator