### PR TITLE
README: make it clear this health panel is about check Laravel apps only

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![Latest Stable Version](https://img.shields.io/packagist/v/pragmarx/health.svg?style=flat-square)](https://packagist.org/packages/pragmarx/health) [![License](https://img.shields.io/badge/license-BSD_3_Clause-brightgreen.svg?style=flat-square)](LICENSE) [![Downloads](https://img.shields.io/packagist/dt/pragmarx/health.svg?style=flat-square)](https://packagist.org/packages/pragmarx/health) [![Code Quality](https://img.shields.io/scrutinizer/g/antonioribeiro/health.svg?style=flat-square)](https://scrutinizer-ci.com/g/antonioribeiro/health/?branch=master) [![Build](https://img.shields.io/scrutinizer/build/g/antonioribeiro/health.svg?style=flat-square)](https://scrutinizer-ci.com/g/antonioribeiro/health/?branch=master) [![Build](https://img.shields.io/scrutinizer/coverage/g/antonioribeiro/health.svg?style=flat-square)](https://scrutinizer-ci.com/g/antonioribeiro/health/?branch=master) [![StyleCI](https://styleci.io/repos/74829244/shield)](https://styleci.io/repos/74829244)
 
-This package checks if the application resources are running as they should and creates a service status panel. It has the following main points:
+This package checks if the _Laravel application resources_ are running as they should and creates a service status panel. It has the following main points:
 
 - Highly extensible and configurable: you can create new checkers and notifiers very easily, and you can virtually change everything on it.
 - Easy configuration: uses YAML as configuration files


### PR DESCRIPTION
Well, I must have been misleaded by the shinny screenshots. I first thought this was a monitoring panel (built with Laravel) to monitor any service (not related to any Laravel app). 

I hope this change in the description sentence will help others that stumble upon this doc understand it all about monitoring one Laravel app ;)