### PR TITLE
Notification email improvements - error message included and custom subject line

### DIFF
--- a/src/Notifications/HealthStatus.php
+++ b/src/Notifications/HealthStatus.php
@@ -120,6 +120,7 @@ class HealthStatus extends Notification
     {
         return (new MailMessage())
             ->line($this->getMessage($notifiable))
+            ->line($this->result->errorMessage)
             ->from(
                 config('health.notifications.from.address'),
                 config('health.notifications.from.name')

--- a/src/Notifications/HealthStatus.php
+++ b/src/Notifications/HealthStatus.php
@@ -125,6 +125,7 @@ class HealthStatus extends Notification
                 config('health.notifications.from.address'),
                 config('health.notifications.from.name')
             )
+            ->subject($this->getSubject())
             ->action($this->getActionTitle(), $this->getActionLink());
     }
 
@@ -149,6 +150,16 @@ class HealthStatus extends Notification
     protected function getActionTitle()
     {
         return config('health.notifications.action-title');
+    }
+
+    /**
+     * Get the email subject.
+     *
+     * @return mixed
+     */
+    protected function getSubject()
+    {
+        return config('health.notifications.subject');
     }
 
     /**

--- a/src/config/health.php
+++ b/src/config/health.php
@@ -187,6 +187,8 @@ return [
             'resource' => false,
         ],
 
+        'subject' => 'Health Status',
+
         'action-title' => 'View App Health',
 
         'action_message' => "The '%s' service is in trouble and needs attention%s",


### PR DESCRIPTION
This PR makes two improvements to the notification email:

1. Previously, the email was only showing the action message in the email, which was something like `The '{{ resource }}' service is in trouble and needs attention in {{ url }}.` This message was not very helpful as it did not show why something was failing, requiring someone to click to the panel to see. If someone got an email in the middle of the night and went to check the health panel when they woke up, often the error would have cleared and it would be difficult/impossible to track down what the original failure was.<br><br>To fix this, the error message is now included as a new line in the email. If for some reason no error message exists, the email will still send, just with that line omitted.

2. If this package is used across multiple applications and environments, the subject line for the email is not descriptive as to where the issue occurred.<br><br>To fix this, a user can now set a custom subject in their config by changing the `notifications.subject` property in the config. They could change it to something like `'subject' => '['.config('app.env').'] '.config('app.name').' Health Status',` which provides more info about which health status this is for. If the subject is null (because someone hasn't updated their config file), the name of the notification class will be used.