### PR TITLE
small fix for laravel 6 compatibility   

### DIFF
--- a/src/Checkers/Mail.php
+++ b/src/Checkers/Mail.php
@@ -4,6 +4,7 @@ namespace PragmaRX\Health\Checkers;
 
 use PragmaRX\Health\Support\Result;
 use Illuminate\Support\Facades\Mail as IlluminateMail;
+use Illuminate\Support\Arr;
 
 class Mail extends Base
 {
@@ -70,7 +71,7 @@ class Mail extends Base
     private function sendMail()
     {
         IlluminateMail::send($this->target->view, [], function ($message) {
-            $fromAddress = array_get($this->target->config, 'from.address');
+            $fromAddress = Arr::get($this->target->config, 'from.address');
 
             $message->returnPath($fromAddress);
 

--- a/src/Checkers/Mail.php
+++ b/src/Checkers/Mail.php
@@ -2,9 +2,9 @@
 
 namespace PragmaRX\Health\Checkers;
 
-use PragmaRX\Health\Support\Result;
-use Illuminate\Support\Facades\Mail as IlluminateMail;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Mail as IlluminateMail;
+use PragmaRX\Health\Support\Result;
 
 class Mail extends Base
 {

--- a/src/Notifications/HealthStatus.php
+++ b/src/Notifications/HealthStatus.php
@@ -2,11 +2,12 @@
 
 namespace PragmaRX\Health\Notifications;
 
-use Request;
 use Illuminate\Bus\Queueable;
-use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Messages\SlackMessage;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Str;
+use Request;
 
 class HealthStatus extends Notification
 {
@@ -173,7 +174,7 @@ class HealthStatus extends Notification
 
         return sprintf(
             $this->getActionMessage($this),
-            studly_case($this->resource->name),
+            Str::studly($this->resource->name),
             $domain ? " in {$domain}." : '.'
         );
     }


### PR DESCRIPTION
after upgrading to laravel 6 i got two exceptions
1.Call to undefined function PragmaRX\Health\Checkers\array_get() . 
2. Call to undefined function PragmaRX\Health\Notifications\studly_case()
So i made this PR to fix these problems . please let me know if i'm doing anything wrong
Thanks in advance. 
