### PR TITLE
Added $dateFormat for MS SQL Server support

### DIFF
--- a/src/Data/Models/HealthCheck.php
+++ b/src/Data/Models/HealthCheck.php
@@ -28,4 +28,10 @@ class HealthCheck extends Model
      * @var string
      */
     const UPDATED_AT = null;
+    
+     /**
+     * @var string
+     * Set $dateFormat due to Carbon rawCreateFromFormat issue with MS SQL Server datetime format, which includes milliseconds.
+     */
+    protected $dateFormat = 'Y-m-d H:i:s';
 }


### PR DESCRIPTION
Hi,

I am a big fan of this Health Panel package and I am currently integrating it into one of our projects at work.

Because we connect to MS SQL Server as opposed to MySQL, MariaDB, etc., we often come across date time format issues.

We are able to successfully over come this in a variety of ways, e.g., creating base models, setting the $dateFormat directly in our models.

However, in this case, in using this great package, overriding the src model is of course, not a great idea.

It would be great if you could either add this directly to the model, or, even better... maybe, make this a config setting that I can specify.

Thank you for your consideration!
Rick