### PR TITLE
support phpunit/php-timer 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": ">=7.0",
         "illuminate/support": ">=5.5",
         "pragmarx/yaml": ">=0.1",
-        "phpunit/php-timer": "^1.0|^2.0",
+        "phpunit/php-timer": "^1.0|^2.0|^3.0",
         "ext-json": "*"
     },
     "require-dev": {


### PR DESCRIPTION
See #175 

This adds support for the newest version of `phpunit/php-timer`.