### PR TITLE
Fixed the deprecated use of implode

### DIFF
--- a/src/Checkers/Mail.php
+++ b/src/Checkers/Mail.php
@@ -2,6 +2,7 @@
 
 namespace PragmaRX\Health\Checkers;
 
+use Illuminate\Support\Arr;
 use PragmaRX\Health\Support\Result;
 use Illuminate\Support\Facades\Mail as IlluminateMail;
 
@@ -70,7 +71,7 @@ class Mail extends Base
     private function sendMail()
     {
         IlluminateMail::send($this->target->view, [], function ($message) {
-            $fromAddress = array_get($this->target->config, 'from.address');
+            $fromAddress = Arr::get($this->target->config, 'from.address');
 
             $message->returnPath($fromAddress);
 

--- a/src/Checkers/Ping.php
+++ b/src/Checkers/Ping.php
@@ -122,7 +122,7 @@ class Ping extends Base
 
         // Strip empty lines and reorder the indexes from 0 (to make results more
         // uniform across OS versions).
-        $this->commandOutput = implode($output, '');
+        $this->commandOutput = implode($output);
         $output = array_values(array_filter($output));
 
         // If the result line in the output is not empty, parse it.


### PR DESCRIPTION
To avoid conflicts between versions using the glue as first param and deprecated versions using it as second, I suggest simply dropping the glue and let the function use the default.