### PR TITLE
fix: pass singleton() a closure instead of an object

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -3,16 +3,16 @@
 namespace PragmaRX\Health;
 
 use Event;
-use PragmaRX\Yaml\Package\Yaml;
-use PragmaRX\Health\Support\Cache;
 use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Support\ServiceProvider as IlluminateServiceProvider;
+use PragmaRX\Health\Console\Commands as ConsoleCommands;
+use PragmaRX\Health\Events\RaiseHealthIssue;
+use PragmaRX\Health\Listeners\NotifyHealthIssue;
+use PragmaRX\Health\Support\Cache;
+use PragmaRX\Health\Support\ResourceChecker;
 use PragmaRX\Health\Support\ResourceLoader;
 use PragmaRX\Health\Support\Traits\Routing;
-use PragmaRX\Health\Events\RaiseHealthIssue;
-use PragmaRX\Health\Support\ResourceChecker;
-use PragmaRX\Health\Listeners\NotifyHealthIssue;
-use PragmaRX\Health\Console\Commands as ConsoleCommands;
-use Illuminate\Support\ServiceProvider as IlluminateServiceProvider;
+use PragmaRX\Yaml\Package\Yaml;
 
 class ServiceProvider extends IlluminateServiceProvider
 {
@@ -317,7 +317,9 @@ class ServiceProvider extends IlluminateServiceProvider
 
         $this->app->singleton(
             'pragmarx.health.commands',
-            $this->instantiateCommands()
+            function () {
+                return $this->instantiateCommands();
+            }
         );
     }
 


### PR DESCRIPTION
Laravel 7.22.0 (https://github.com/laravel/framework/releases/tag/v7.22.0) throws `TypeError`s when passed an object instead of a closure or class name.

Fixes #183