### PR TITLE
Remove arrow functions

### DIFF
--- a/src/Checkers/Certificate.php
+++ b/src/Checkers/Certificate.php
@@ -103,7 +103,9 @@ class Certificate extends Base
 
             'php' => $this->checkCertificateWithPhp($host),
         ])
-            ->filter(function ($result) { return $result[0] === false; })
+            ->filter(function ($result) {
+                return $result[0] === false;
+            })
             ->first();
 
         if ($result === null) {

--- a/src/Checkers/Certificate.php
+++ b/src/Checkers/Certificate.php
@@ -103,7 +103,7 @@ class Certificate extends Base
 
             'php' => $this->checkCertificateWithPhp($host),
         ])
-            ->filter(fn ($result) => $result[0] === false)
+            ->filter(function ($result) { return $result[0] === false; })
             ->first();
 
         if ($result === null) {
@@ -119,10 +119,12 @@ class Certificate extends Base
 
         $result = collect($output)
             ->filter(
-                fn ($line) => Str::contains(
-                    $line,
-                    $this->target->resource->verifyString
-                )
+                function ($line) {
+                    return Str::contains(
+                        $line,
+                        $this->target->resource->verifyString
+                    );
+                }
             )
             ->first();
 


### PR DESCRIPTION
Arrow functions are only usable in php 7.4; Project is listed as 7.1+