### PR TITLE
default extension checker config fix

### DIFF
--- a/src/config/resources/Extensions.yml
+++ b/src/config/resources/Extensions.yml
@@ -6,7 +6,7 @@ error_message:
   "The following extensions are not installed or enabled: %s"
 column_size: 3
 targets:
-  default:
+  - default:
     - items:
         - Core
         - phpdbg_webhelper


### PR DESCRIPTION
extension checked had an annoying `0` in its selector, since the targets got ilformatted yml input. this makes it to a proper format, to hide it.