### PR TITLE
default extension checker config fix

### DIFF
--- a/src/config/resources/Extensions.yml
+++ b/src/config/resources/Extensions.yml
@@ -6,8 +6,8 @@ error_message:
   "The following extensions are not installed or enabled: %s"
 column_size: 3
 targets:
-  default:
-    - items:
+  - default:
+    items:
         - Core
         - phpdbg_webhelper
         - date


### PR DESCRIPTION
extension checked had an annoying `0` in its selector, since the targets got ilformatted yml input. this makes it to a proper format, to hide it.

also supports multiple extension checkers.

![image](https://user-images.githubusercontent.com/375078/146641339-26b120bc-6068-4553-9e90-7b10f3f8b31a.png)
