### PR TITLE
Update Database.php

### DIFF
--- a/src/Checkers/Database.php
+++ b/src/Checkers/Database.php
@@ -52,7 +52,7 @@ class Database extends Base
         Timer::start();
 
         DB::connection($this->getConnectionName())->select(
-            DB::raw($this->target->query)
+            $this->target->query
         );
 
         $took = round(Timer::stop(), 5);


### PR DESCRIPTION
Fix Database Checkers Error In Laravel 10.
Since Laravel 10, DB::select method doesn't require Expression object(DB::raw)