### PR TITLE
[Composer] Add support for Laravel 10.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": ">=7.3",
         "illuminate/support": ">=8.0",
         "pragmarx/yaml": ">=0.1",
-        "phpunit/php-timer": "^1.0|^2.0|^3.0|^4.0|^5.0",
+        "phpunit/php-timer": "^1.0|^2.0|^3.0|^4.0|^5.0|^6.0",
         "ext-json": "*"
     },
     "require-dev": {


### PR DESCRIPTION
This PR allows this package to be installed on Laravel 10. I came accross this when trying to upgrade project from Laravel 9.x.
Laravel 10 requires phpunit ^10. wchich underneath uses phpunit/php-timer ^6.0

Updates:
Composer only
Added "^6.0" in "require" "phpunit/php-timer" 